### PR TITLE
refactor: update to match changes from upstream api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "frankfurter_cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "lib_frankfurter"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chrono",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Rolv Apneseth"]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 readme = "./README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ To set up and use a self-hosted version of the API, follow these steps:
 1. Copy/clone the `docker-compose.yml` file to your system
 2. Run `docker compose up -d --wait` to start up both the `postgresql` database and the `Frankfurter` API itself locally using Docker
 3. When running commands, specify the desired API URL using either the `--url` flag or the `FRANKFURTER_URL` environment variable:
-    - `frs --url http://localhost:8080`
-    - `FRANKFURTER_URL="http://localhost:8080 frs`
+    - `frs --url http://localhost:8080/v1`
+    - `FRANKFURTER_URL="http://localhost:8080/v1 frs`
 
 ## Related Projects
 

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -25,7 +25,7 @@ pub struct Cli {
     #[arg(short, long, value_name = "WHEN", default_value_t = clap::ColorChoice::default(), ignore_case = true)]
     color: clap::ColorChoice,
 
-    ///  URL of the Frankfurter API which queries should be directed to, e.g. http://localhost:8080
+    ///  URL of the Frankfurter API which queries should be directed to, e.g. http://localhost:8080/v1
     ///
     /// This will override the $FRANKFURTER_URL environment variable if it is present.
     #[arg(short, long)]

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -6,7 +6,7 @@ use predicates::{
 
 fn get_cmd() -> Command {
     let mut cmd = Command::cargo_bin("frs").unwrap();
-    cmd.arg("--url=http://localhost:8080");
+    cmd.arg("--url=http://localhost:8080/v1");
     cmd
 }
 

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -4,10 +4,30 @@ use predicates::{
     str::{contains, ends_with, is_match, starts_with},
 };
 
+const BIN: &str = "frs";
+
 fn get_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("frs").unwrap();
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
     cmd.arg("--url=http://localhost:8080/v1");
     cmd
+}
+
+#[test]
+fn test_error_response() {
+    const URL: &str = "http://localhost:8080/invalid";
+    Command::cargo_bin(BIN)
+        .unwrap()
+        .arg(format!("--url={URL}"))
+        .arg("currencies")
+        .assert()
+        .stderr(
+            contains("URL")
+                .and(contains(URL))
+                .and(contains("Status"))
+                .and(contains("404"))
+                .and(contains("Status")),
+        )
+        .failure();
 }
 
 #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 10
 
   api:
-    image: hakanensari/frankfurter
+    image: lineofflight/frankfurter
     container_name: frankfurter-api
     restart: unless-stopped
     ports:
@@ -34,7 +34,7 @@ services:
     healthcheck:
       test: curl --fail http://localhost:8080 || exit 1
       interval: 1s
-      timeout: 5s
+      timeout: 10s
       retries: 10
 
 networks:

--- a/lib/examples/basic.rs
+++ b/lib/examples/basic.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 #[tokio::main]
 async fn main() {
-    let server_client: ServerClient = Url::parse("http://localhost:8080")
+    let server_client: ServerClient = Url::parse("http://localhost:8080/v1")
         .map(ServerClient::new)
         .unwrap_or_default();
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -18,11 +18,6 @@ pub enum Error {
     #[error("The start date ({0}) is past the latest date with exchange rates")]
     RequestLateStartDate(NaiveDate),
 
-    #[error(
-        "The requested dates ({start} and {end}) are during a single weekend, for which exchange rates are not available"
-    )]
-    RequestWeekendDates { start: NaiveDate, end: NaiveDate },
-
     /// Error from [`reqwest`], see [`reqwest::Error`].
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDate;
+use reqwest::StatusCode;
 
 use crate::data::Currency;
 
@@ -17,6 +18,13 @@ pub enum Error {
 
     #[error("The start date ({0}) is past the latest date with exchange rates")]
     RequestLateStartDate(NaiveDate),
+
+    #[error("Invalid response from the API\n  URL - {url}\n  Status - {status}\n  Body - {body}")]
+    InvalidResponse {
+        url: String,
+        status: StatusCode,
+        body: String,
+    },
 
     /// Error from [`reqwest`], see [`reqwest::Error`].
     #[error(transparent)]

--- a/lib/tests/base.rs
+++ b/lib/tests/base.rs
@@ -1,5 +1,5 @@
 mod shared;
-use shared::get_server;
+use shared::{get_invalid_server, get_server};
 
 #[tokio::test]
 async fn local_api_is_available() {
@@ -14,4 +14,8 @@ async fn endpoint_currencies() {
     let server = get_server();
     let res = server.currencies(Default::default()).await.unwrap();
     assert!(res.0.len() > 10);
+
+    // ERROR RESPONSE FROM API
+    let server = get_invalid_server();
+    assert!(server.currencies(Default::default()).await.is_err())
 }

--- a/lib/tests/endpoint_convert.rs
+++ b/lib/tests/endpoint_convert.rs
@@ -5,7 +5,7 @@ use lib_frankfurter::{
     data::{Currency, CurrencyValue},
 };
 use pretty_assertions::assert_eq;
-use shared::get_server;
+use shared::{get_invalid_server, get_server};
 
 #[tokio::test]
 async fn endpoint_convert() {
@@ -39,4 +39,8 @@ async fn endpoint_convert() {
     let date = NaiveDate::from_ymd_opt(2024, 8, 20).unwrap();
     let res = make_request(convert::Request::default().with_date(date)).await;
     assert_eq!(res.date, date);
+
+    // ERROR RESPONSE FROM API
+    let server = get_invalid_server();
+    assert!(server.convert(Default::default()).await.is_err())
 }

--- a/lib/tests/endpoint_period.rs
+++ b/lib/tests/endpoint_period.rs
@@ -5,7 +5,7 @@ use lib_frankfurter::{
     data::{Currency, CurrencyValue},
 };
 use pretty_assertions::assert_eq;
-use shared::get_server;
+use shared::{get_invalid_server, get_server};
 
 #[tokio::test]
 async fn endpoint_period() {
@@ -63,4 +63,8 @@ async fn endpoint_period() {
         // Start -> end date (inclusive)
         (end_date.num_days_from_ce() - start_date.num_days_from_ce() + 1) as usize
     );
+
+    // ERROR RESPONSE FROM API
+    let server = get_invalid_server();
+    assert!(server.period(Default::default()).await.is_err())
 }

--- a/lib/tests/shared/mod.rs
+++ b/lib/tests/shared/mod.rs
@@ -4,7 +4,7 @@ use lib_frankfurter::api;
 use url::Url;
 
 /// URL for locally hosted API
-static URL: LazyLock<Url> = LazyLock::new(|| Url::parse("http://localhost:8080").unwrap());
+static URL: LazyLock<Url> = LazyLock::new(|| Url::parse("http://localhost:8080/v1").unwrap());
 
 pub fn get_server() -> api::ServerClient {
     api::ServerClient::new(URL.clone())

--- a/lib/tests/shared/mod.rs
+++ b/lib/tests/shared/mod.rs
@@ -5,7 +5,13 @@ use url::Url;
 
 /// URL for locally hosted API
 static URL: LazyLock<Url> = LazyLock::new(|| Url::parse("http://localhost:8080/v1").unwrap());
+static INVALID_URL: LazyLock<Url> =
+    LazyLock::new(|| Url::parse("http://localhost:8080/invalid").unwrap());
 
 pub fn get_server() -> api::ServerClient {
     api::ServerClient::new(URL.clone())
+}
+
+pub fn get_invalid_server() -> api::ServerClient {
+    api::ServerClient::new(INVALID_URL.clone())
 }


### PR DESCRIPTION
- Remove weekend errors and error when asking for period data for today before data for the day is fetched, see [upstream issue](https://github.com/lineofflight/frankfurter/issues/71)
- Append `/v1` path to locally hosted API paths
- Update username for docker image
- Add error for when the API responds with an error status