### PR TITLE
refactor: changes to match the upstream API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "frankfurter_cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "lib_frankfurter"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chrono",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Rolv Apneseth"]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 readme = "./README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![AUR](https://img.shields.io/aur/version/frs)](https://aur.archlinux.org/packages/frs)
 
 Rust library and CLI to interface with any Frankfurter API.
-> *[Frankfurter](https://github.com/hakanensari/frankfurter) is a free, open source and [self-hostable](https://hub.docker.com/r/hakanensari/frankfurter) currency exchange rate API.
+> *[Frankfurter](https://github.com/lineofflight/frankfurter) is a free, open source and [self-hostable](https://hub.docker.com/r/lineofflight/frankfurter) currency exchange rate API.
 > It is based on [data sets](https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html) published by the European Central Bank.*
 
 ## Table of Contents
@@ -81,15 +81,15 @@ View the full usage with `frs --help`.
 
 ### Self-hosting
 
-A public, free-to-use version of the API is available [here](https://api.frankfurter.app/), and will be used by default. However, this repo comes with a [docker-compose.yml](./docker-compose.yml) for easy self-hosting of the `Frankfurter` API.
+A public, free-to-use version of the API is available [here](https://api.frankfurter.dev/), and will be used by default. However, this repo comes with a [docker-compose.yml](./docker-compose.yml) for easy and convenient self-hosting of the `Frankfurter` API.
 
 To set up and use a self-hosted version of the API, follow these steps:
 
 1. Copy/clone the `docker-compose.yml` file to your system
-2. Run `docker compose up -d --wait` to start up both the `postgresql` database and the `Frankfurter` API itself locally using Docker
+2. Run `docker compose up -d --wait` to start up the `Frankfurter` API, which includes a `SQLite` database, locally using Docker
 3. When running commands, specify the desired API URL using either the `--url` flag or the `FRANKFURTER_URL` environment variable:
-    - `frs --url http://localhost:8080/v1`
-    - `FRANKFURTER_URL="http://localhost:8080/v1 frs`
+    - `frs --url http://localhost:8080`
+    - `FRANKFURTER_URL="http://localhost:8080 frs`
 
 ## Contributing
 
@@ -102,7 +102,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 ### Suggested workflow
 
 1. Make your changes
-2. Ensure your changes do what you intend by adding tests. Use `just develop` to run the tests every time you make a change (just remember to take down the docker containers down afterwards with `just docker_down`), or `just test` to run them once.
+2. Ensure your changes do what you intend by adding tests. Use `just develop` to run the tests every time you make a change, or `just test` to run them once.
     - If your changes are for the CLI you can also check manually by running `cargo run -- -d {args here}`.
 3. Format and lint your code (requires the nightly Rust toolchain) with `just format`
 
@@ -112,7 +112,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 ## Credit
 
-- [Frankfurter](https://github.com/hakanensari/frankfurter) of course, for be the underlying API that this project wraps
+- [Frankfurter](https://github.com/lineofflight/frankfurter) of course, for be the underlying API that this project wraps
 - [LanguageTool-Rust](https://github.com/jeertmans/languagetool-rust) for inspiration and a look at how Rust API bindings should look/function
 
 ## Licence  

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -25,7 +25,7 @@ pub struct Cli {
     #[arg(short, long, value_name = "WHEN", default_value_t = clap::ColorChoice::default(), ignore_case = true)]
     color: clap::ColorChoice,
 
-    ///  URL of the Frankfurter API which queries should be directed to, e.g. http://localhost:8080/v1
+    ///  URL of the Frankfurter API which queries should be directed to, e.g. http://localhost:8080
     ///
     /// This will override the $FRANKFURTER_URL environment variable if it is present.
     #[arg(short, long)]

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -8,7 +8,7 @@ const BIN: &str = "frs";
 
 fn get_cmd() -> Command {
     let mut cmd = Command::cargo_bin(BIN).unwrap();
-    cmd.arg("--url=http://localhost:8080/v1");
+    cmd.arg("--url=http://localhost:8080");
     cmd
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,14 @@
 version: "3"
 services:
-  db:
-    image: postgres:15
-    container_name: frankfurter-db
-    environment:
-      - PGUSER=postgres
-      - POSTGRES_PASSWORD=password
-    volumes:
-      - ./api_data:/var/lib/postgresql/data
-    ports:
-      - 5432:5432
-    networks:
-      - postgres-db-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
-      interval: 1s
-      timeout: 5s
-      retries: 10
-
   api:
     image: lineofflight/frankfurter
     container_name: frankfurter-api
-    restart: unless-stopped
+    restart: no
+    pull_policy: always
     ports:
       - "8080:8080"
-    environment:
-      DATABASE_URL: postgresql://postgres:password@db:5432/postgres
-    depends_on:
-      db:
-        condition: service_healthy
-    networks:
-      - postgres-db-network
     healthcheck:
       test: curl --fail http://localhost:8080 || exit 1
-      interval: 1s
-      timeout: 10s
+      interval: 2s
+      timeout: 20s
       retries: 10
-
-networks:
-  postgres-db-network:
-    driver: bridge

--- a/lib/examples/basic.rs
+++ b/lib/examples/basic.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 #[tokio::main]
 async fn main() {
-    let server_client: ServerClient = Url::parse("http://localhost:8080/v1")
+    let server_client: ServerClient = Url::parse("http://localhost:8080")
         .map(ServerClient::new)
         .unwrap_or_default();
 

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -26,7 +26,7 @@ pub struct ServerClient {
 impl Default for ServerClient {
     fn default() -> Self {
         Self {
-            url: Url::parse("https://api.frankfurter.app")
+            url: Url::parse("https://api.frankfurter.dev/v1")
                 .expect("Invalid fallback Frankfurter API URL"),
             client: Default::default(),
         }
@@ -41,6 +41,9 @@ impl ServerClient {
         {
             frankfurter_api_url.path_segments_mut().unwrap().pop();
         }
+
+        // Append `/v1` to use correct version of the API
+        frankfurter_api_url.path_segments_mut().unwrap().push("v1");
 
         Self {
             url: frankfurter_api_url,

--- a/lib/tests/shared/mod.rs
+++ b/lib/tests/shared/mod.rs
@@ -4,7 +4,7 @@ use lib_frankfurter::api;
 use url::Url;
 
 /// URL for locally hosted API
-static URL: LazyLock<Url> = LazyLock::new(|| Url::parse("http://localhost:8080/v1").unwrap());
+static URL: LazyLock<Url> = LazyLock::new(|| Url::parse("http://localhost:8080").unwrap());
 static INVALID_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("http://localhost:8080/invalid").unwrap());
 


### PR DESCRIPTION
Changes include:

- using a SQLite database instead of PostgreSQL, so the `docker-compose.yml` is much simpler now 
- a new domain with a requirement for the versioned paths, meaning the `/v1` can just be a requirement for both the locally hosted and remote API