### PR TITLE
ci: releases and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      deps:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Build and release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*.*.*
+
+env:
+  CARGO_TERM_COLOR: always
+  NAME: frs
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create the release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Create the release
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create --title "$GITHUB_REF_NAME" "$GITHUB_REF_NAME"
+
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    needs: release
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+
+          - target: x86_64-apple-darwin
+            os: macos-latest
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Install musl libc
+        if: ${{ contains(matrix.target, 'musl') }}
+        run: sudo apt install musl-tools
+
+      - name: Set up Rust
+        run: rustup update stable && rustup target add ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Create the archive
+        env:
+          BIN: frs
+        run: |
+          if [[ ${{ matrix.os }} == *windows* ]]; then
+            BIN="$BIN.exe"
+            ARCHIVER=(7z a)
+            EXTENSION="zip"
+          else
+            ARCHIVER=(tar -czvf)
+            EXTENSION="tar.gz"
+          fi
+
+          mv "target/${{ matrix.target }}/release/$BIN" "$BIN"
+          "${ARCHIVER[@]}" "$NAME-$GITHUB_REF_NAME-${{ matrix.target }}.$EXTENSION" "$BIN" LICENSE README.md
+
+      - name: Upload the archive
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" "$NAME"-*
+
+      - name: Attest release files
+        id: attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '*.zip, *.tar.gz'

--- a/cli/src/cli/convert.rs
+++ b/cli/src/cli/convert.rs
@@ -91,7 +91,7 @@ impl ExecuteSubcommand for Command {
                     ]
                 }));
 
-            writeln!(&mut stdout, "{}", table)?;
+            writeln!(&mut stdout, "{table}")?;
         }
 
         Ok(())

--- a/cli/src/cli/currencies.rs
+++ b/cli/src/cli/currencies.rs
@@ -55,7 +55,7 @@ impl ExecuteSubcommand for Command {
                     ]
                 }));
 
-            writeln!(&mut stdout, "{}", table)?;
+            writeln!(&mut stdout, "{table}")?;
         }
 
         Ok(())

--- a/cli/src/cli/period.rs
+++ b/cli/src/cli/period.rs
@@ -113,7 +113,7 @@ impl ExecuteSubcommand for Command {
                 }
             }
 
-            writeln!(&mut stdout, "{}", table)?;
+            writeln!(&mut stdout, "{table}")?;
         }
 
         Ok(())


### PR DESCRIPTION
"Borrowed" some files from [tlrc](https://github.com/tldr-pages/tlrc) to try and set up releases for the `frs` binary - we'll see if it works